### PR TITLE
Updating the doc to use bash instead of sh

### DIFF
--- a/how-to/install.ftd
+++ b/how-to/install.ftd
@@ -18,7 +18,7 @@ You can get our pre-compiled binaries in the
 --- ft.code:
 lang: sh
 
-\$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/FifthTry/fpm/main/install-fpm.sh)"
+\$ sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/FifthTry/fpm/main/install-fpm.sh)"
 
 -- ft.h3: Download and map the binaries
 


### PR DESCRIPTION
- Switching to bash for installing fpm in linux systems 
- To avoid backward-incompatibility issue with sh while executing install-fpm.sh